### PR TITLE
Added default OBERON_BIN if not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ JAVA_SOURCES = src/java/Files_FileDesc.java src/java/Files.java \
 MOD_SOURCES = src/Out.Mod src/Os.Mod src/Files.Mod src/Strings.Mod src/OJS.Mod \
               src/CpCache.Mod src/Opcodes.Mod src/ClassFormat.Mod src/OJB.Mod \
               src/OJG.Mod src/OJP.Mod src/oberonc.Mod src/In.Mod src/Math.Mod
+OBERON_BIN ?= bin
 
 build:
 	mkdir -p out/


### PR DESCRIPTION
Tweaked runtime path to make target: runFern work
Tweaked runtime path to make target: test work
FWIW, tested on Fedora 34 Linux using JDK 11.

Hi Luca! it's Darrell.  
I decided to kick the tires of your project and these were the things I changed to make it work on my machine.
Maybe you will find them useful.