### PR TITLE
Set default OBERON_BIN if not already set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bootstrapOut/
+examples/fern/out/
+out/
+tests/out/
+

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ JAVA_SOURCES = src/java/Files_FileDesc.java src/java/Files.java \
 MOD_SOURCES = src/Out.Mod src/Os.Mod src/Files.Mod src/Strings.Mod src/OJS.Mod \
               src/CpCache.Mod src/Opcodes.Mod src/ClassFormat.Mod src/OJB.Mod \
               src/OJG.Mod src/OJP.Mod src/oberonc.Mod src/In.Mod src/Math.Mod
+OBERON_BIN ?= $(realpath ./bin)
 
 build:
 	mkdir -p out/
@@ -30,7 +31,7 @@ runFern:
 	rm -rf examples/fern/out/
 	mkdir -p examples/fern/out/
 	javac -cp $(OBERON_BIN) -d examples/fern/out examples/fern/java/*.java
-	java -cp $(OBERON_BIN) oberonc examples/fern/out \
+	OBERON_BIN=${OBERON_BIN} java -cp $(OBERON_BIN) oberonc examples/fern/out \
 	  examples/fern/RandomNumbers.Mod \
 	  examples/fern/XYplane.Mod examples/fern/IFS.Mod
 	java -cp $(OBERON_BIN):examples/fern/out IFS
@@ -39,7 +40,7 @@ test:
 	rm -rf tests/out/
 	mkdir -p tests/out/
 	javac -cp $(OBERON_BIN) -d tests/out tests/TestRunner.java
-	java -Dfile.encoding=UTF-8 -cp $(OBERON_BIN):tests/out TestRunner
+	OBERON_BIN=${OBERON_BIN} java -Dfile.encoding=UTF-8 -cp $(OBERON_BIN):tests/out TestRunner
 
 
 clean:


### PR DESCRIPTION
Ok, this might be the best of both worlds.

This change works OOTB, and shouldn't stomp any previously set OBERON_BIN if it is already set.