### PR TITLE
create symbol files on a file by file basis

### DIFF
--- a/src/oberonc.Mod
+++ b/src/oberonc.Mod
@@ -36,7 +36,9 @@ IMPORT OJS, OJP, Out, Strings;
         IF arg[len-1] = "+" THEN
           newSym := TRUE;
           arg[len-1] := 0X
-        END ;
+	ELSE
+	  newSym := FALSE
+        END;
         OJP.Compile(arg, newSym, folder)
       END
     END


### PR DESCRIPTION
newSym is set to TRUE and all modules following are exported with symbol files, even if they don't end in '+'. So I reset the flag, if no '+' is present.